### PR TITLE
Order item options now returns names based on option(value) reference.

### DIFF
--- a/src/Entity/OrderItemOption.php
+++ b/src/Entity/OrderItemOption.php
@@ -126,6 +126,10 @@ class OrderItemOption implements OrderItemOptionInterface
     /** {@inheritdoc} */
     public function getCustomerOptionName(): string
     {
+        if (null !== $this->customerOption) {
+            return $this->customerOption->getName();
+        }
+
         return $this->customerOptionName;
     }
 
@@ -159,6 +163,10 @@ class OrderItemOption implements OrderItemOptionInterface
     /** {@inheritdoc} */
     public function getCustomerOptionValueName(): string
     {
+        if (null !== $this->customerOptionValue) {
+            return $this->customerOptionValue->getName();
+        }
+
         return $this->customerOptionValueName ?? ($this->optionValue ?? '');
     }
 


### PR DESCRIPTION
The hard copied values are used when no reference exists.