### PR TITLE
Fix order item option updater

### DIFF
--- a/src/Resources/config/app/services/services.xml
+++ b/src/Resources/config/app/services/services.xml
@@ -22,7 +22,6 @@
 
         <service class="Brille24\SyliusCustomerOptionsPlugin\Services\OrderItemOptionUpdater"
                  id="brille24.sylius_customer_options_plugin.services.order_item_option_updater">
-            <argument type="service" id="brille24.repository.customer_option" />
             <argument type="service" id="brille24.customer_options_plugin.factory.order_item_option_factory" />
             <argument type="service" id="brille24.manager.order_item_option" />
         </service>

--- a/src/Services/OrderItemOptionUpdater.php
+++ b/src/Services/OrderItemOptionUpdater.php
@@ -7,6 +7,7 @@ namespace Brille24\SyliusCustomerOptionsPlugin\Services;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionValueInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
+use Brille24\SyliusCustomerOptionsPlugin\Entity\ProductInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Factory\OrderItemOptionFactoryInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Repository\CustomerOptionRepositoryInterface;
 use Doctrine\ORM\EntityManagerInterface;
@@ -14,11 +15,6 @@ use Webmozart\Assert\Assert;
 
 final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
 {
-    /**
-     * @var CustomerOptionRepositoryInterface
-     */
-    private $customerOptionRepository;
-
     /**
      * @var OrderItemOptionFactoryInterface
      */
@@ -30,11 +26,9 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
     private $entityManager;
 
     public function __construct(
-        CustomerOptionRepositoryInterface $customerOptionRepository,
         OrderItemOptionFactoryInterface $orderItemOptionFactory,
         EntityManagerInterface $entityManager
     ) {
-        $this->customerOptionRepository = $customerOptionRepository;
         $this->orderItemOptionFactory   = $orderItemOptionFactory;
         $this->entityManager            = $entityManager;
     }
@@ -42,13 +36,9 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
     /** {@inheritdoc} */
     public function updateOrderItemOptions(OrderItemInterface $orderItem, array $data): void
     {
+        $this->createMissingOrderItemOptions($orderItem, $data);
+
         $orderItemOptions = $orderItem->getCustomerOptionConfiguration(true);
-
-        if (count($orderItemOptions) === 0) {
-            $this->createNewOrderItemOptions($orderItem, $data);
-
-            return;
-        }
 
         foreach ($data as $customerOptionCode => $newValue) {
             $orderItemOption = $orderItemOptions[$customerOptionCode] ?? null;
@@ -68,18 +58,26 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
         $this->entityManager->flush();
     }
 
-    private function createNewOrderItemOptions(OrderItemInterface $orderItem, array $data): void
+    private function createMissingOrderItemOptions(OrderItemInterface $orderItem, array $data): void
     {
-        $customerOptionConfiguration = [];
+        /** @var ProductInterface $product */
+        $product = $orderItem->getProduct();
 
-        foreach ($data as $customerOptionCode => $value) {
-            $customerOption  = $this->customerOptionRepository->findOneByCode($customerOptionCode);
-            $orderItemOption = $this->orderItemOptionFactory->createNew($customerOption, $value);
+        $customerOptions = $product->getCustomerOptions();
 
-            $orderItemOption->setOrderItem($orderItem);
+        $customerOptionConfiguration = $orderItem->getCustomerOptionConfiguration();
 
-            $this->entityManager->persist($orderItemOption);
-            $customerOptionConfiguration[] = $orderItemOption;
+        foreach ($customerOptions as $customerOption) {
+            if (array_key_exists($customerOption->getCode(), $data) &&
+                !array_key_exists($customerOption->getCode(), $customerOptionConfiguration)
+            ) {
+                $orderItemOption = $this->orderItemOptionFactory->createNew($customerOption, $data[$customerOption->getCode()]);
+
+                $orderItemOption->setOrderItem($orderItem);
+
+                $this->entityManager->persist($orderItemOption);
+                $customerOptionConfiguration[] = $orderItemOption;
+            }
         }
 
         $orderItem->setCustomerOptionConfiguration($customerOptionConfiguration);


### PR DESCRIPTION
**Before:** The OrderItemOptionUpdater would throw an exception, if you provide a value for an option that is not set on the OrderItem yet.

**After:** The OrderItemOptionUpdater creates a new OrderItemOption for provided options that are not set on the OrderItem yet.