### PR TITLE
Fixing item equality checks

### DIFF
--- a/src/Traits/OrderItemCustomerOptionCapableTrait.php
+++ b/src/Traits/OrderItemCustomerOptionCapableTrait.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Brille24\SyliusCustomerOptionsPlugin\Traits;
 
 use Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionValuePrice;
-use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\ProductInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Enumerations\CustomerOptionTypeEnum;
@@ -94,10 +93,9 @@ trait OrderItemCustomerOptionCapableTrait
      */
     public function equals(SyliusOrderItemInterface $item): bool
     {
-        $parentEquals = parent::equals($item);
-
-        if (!$parentEquals && !$item instanceof OrderItemInterface) {
-            return $parentEquals;
+        // If the product doesn't match for the Sylius implementation then it's not the same.
+        if (!parent::equals($item)) {
+            return false;
         }
 
         if ($item instanceof self) {

--- a/tests/Application/.env.test
+++ b/tests/Application/.env.test
@@ -1,3 +1,5 @@
 APP_SECRET='ch4mb3r0f5ecr3ts'
 
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+
 KERNEL_CLASS='Tests\Brille24\SyliusCustomerOptionsPlugin\Application\Kernel'


### PR DESCRIPTION
When two items have no customer options then Sylius thinks they are the same no matter what items are actually being compared.