### PR TITLE
Disable delete button for used Customer Options

### DIFF
--- a/src/Entity/CustomerOptions/CustomerOption.php
+++ b/src/Entity/CustomerOptions/CustomerOption.php
@@ -16,7 +16,6 @@ use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Enumerations\CustomerOptionTypeEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Resource\Model\ArchivableTrait;
 use Sylius\Component\Resource\Model\TranslatableTrait;
 use Sylius\Component\Resource\Model\TranslationInterface;
 
@@ -26,8 +25,6 @@ class CustomerOption implements CustomerOptionInterface
         __construct as protected initializeTranslationsCollection;
         getTranslation as private doGetTranslation;
     }
-
-    use ArchivableTrait;
 
     /** @var int|null */
     private $id;

--- a/src/Entity/CustomerOptions/CustomerOption.php
+++ b/src/Entity/CustomerOptions/CustomerOption.php
@@ -50,7 +50,7 @@ class CustomerOption implements CustomerOptionInterface
     /** @var ArrayCollection */
     private $groupAssociations;
 
-    /** @var OrderItemOptionInterface */
+    /** @var Collection|OrderItemOptionInterface[] */
     private $orders;
 
     public function __construct()
@@ -59,6 +59,7 @@ class CustomerOption implements CustomerOptionInterface
 
         $this->values            = new ArrayCollection();
         $this->groupAssociations = new ArrayCollection();
+        $this->orders            = new ArrayCollection();
     }
 
     /**
@@ -291,9 +292,9 @@ class CustomerOption implements CustomerOptionInterface
     }
 
     /**
-     * @return OrderItemOptionInterface
+     * @return Collection|OrderItemOptionInterface[]
      */
-    public function getOrders(): OrderItemOptionInterface
+    public function getOrders(): Collection
     {
         return $this->orders;
     }

--- a/src/Entity/CustomerOptions/CustomerOption.php
+++ b/src/Entity/CustomerOptions/CustomerOption.php
@@ -16,6 +16,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Enumerations\CustomerOptionTypeEnum;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\ArchivableTrait;
 use Sylius\Component\Resource\Model\TranslatableTrait;
 use Sylius\Component\Resource\Model\TranslationInterface;
 
@@ -25,6 +26,8 @@ class CustomerOption implements CustomerOptionInterface
         __construct as protected initializeTranslationsCollection;
         getTranslation as private doGetTranslation;
     }
+
+    use ArchivableTrait;
 
     /** @var int|null */
     private $id;

--- a/src/Entity/CustomerOptions/CustomerOptionInterface.php
+++ b/src/Entity/CustomerOptions/CustomerOptionInterface.php
@@ -14,12 +14,11 @@ namespace Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sylius\Component\Resource\Model\ArchivableInterface;
 use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TranslatableInterface;
 
-interface CustomerOptionInterface extends ResourceInterface, CodeAwareInterface, TranslatableInterface, ArchivableInterface
+interface CustomerOptionInterface extends ResourceInterface, CodeAwareInterface, TranslatableInterface
 {
     /**
      * @param string|null $type

--- a/src/Entity/CustomerOptions/CustomerOptionInterface.php
+++ b/src/Entity/CustomerOptions/CustomerOptionInterface.php
@@ -14,11 +14,12 @@ namespace Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Resource\Model\ArchivableInterface;
 use Sylius\Component\Resource\Model\CodeAwareInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TranslatableInterface;
 
-interface CustomerOptionInterface extends ResourceInterface, CodeAwareInterface, TranslatableInterface
+interface CustomerOptionInterface extends ResourceInterface, CodeAwareInterface, TranslatableInterface, ArchivableInterface
 {
     /**
      * @param string|null $type

--- a/src/Resources/config/app/config.yml
+++ b/src/Resources/config/app/config.yml
@@ -1,4 +1,4 @@
 imports:
     - { resource: "resources.yml" }
     - { resource: "services.yml" }
-    - { resource: "grids.yml" }
+    - { resource: "grids/*" }

--- a/src/Resources/config/app/grids.yml
+++ b/src/Resources/config/app/grids.yml
@@ -1,4 +1,0 @@
-imports:
-    - { resource: "grids/customer_options.yml" }
-    - { resource: "grids/customer_option_groups.yml" }
-    - { resource: "grids/products.yml" }

--- a/src/Resources/config/app/grids/customer_option_groups.yml
+++ b/src/Resources/config/app/grids/customer_option_groups.yml
@@ -4,7 +4,7 @@ sylius_grid:
             driver:
                 name: doctrine/orm
                 options:
-                    class: Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionGroup
+                    class: '%brille24.model.customer_option_group.class%'
             fields:
                 code:
                     type: string

--- a/src/Resources/config/app/grids/customer_options.yml
+++ b/src/Resources/config/app/grids/customer_options.yml
@@ -7,7 +7,7 @@ sylius_grid:
             driver:
                 name: doctrine/orm
                 options:
-                    class: Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOption
+                    class: '%brille24.model.customer_option.class%'
             fields:
                 code:
                     type: string
@@ -29,12 +29,6 @@ sylius_grid:
                 code:
                     type: string
                     label: sylius.ui.code
-                archival:
-                    type: exists
-                    label: sylius.ui.archival
-                    options:
-                        field: archivedAt
-                    default_value: false
             actions:
                 main:
                     create:
@@ -45,5 +39,3 @@ sylius_grid:
                     delete:
                         type: delete_unused_customer_option
                         label: 'sylius.ui.delete'
-                    archive:
-                        type: archive

--- a/src/Resources/config/app/grids/customer_options.yml
+++ b/src/Resources/config/app/grids/customer_options.yml
@@ -1,4 +1,7 @@
 sylius_grid:
+    templates:
+        action:
+            delete_unused_customer_option: '@Brille24SyliusCustomerOptionsPlugin/CustomerOption/Buttons/delete.html.twig'
     grids:
         brille24_admin_customer_option_grid:
             driver:
@@ -40,6 +43,7 @@ sylius_grid:
                     update:
                         type: update
                     delete:
-                        type: delete
+                        type: delete_unused_customer_option
+                        label: 'sylius.ui.delete'
                     archive:
                         type: archive

--- a/src/Resources/config/app/grids/customer_options.yml
+++ b/src/Resources/config/app/grids/customer_options.yml
@@ -26,6 +26,12 @@ sylius_grid:
                 code:
                     type: string
                     label: sylius.ui.code
+                archival:
+                    type: exists
+                    label: sylius.ui.archival
+                    options:
+                        field: archivedAt
+                    default_value: false
             actions:
                 main:
                     create:
@@ -35,3 +41,5 @@ sylius_grid:
                         type: update
                     delete:
                         type: delete
+                    archive:
+                        type: archive

--- a/src/Resources/config/app/routing/admin/customer_options.yml
+++ b/src/Resources/config/app/routing/admin/customer_options.yml
@@ -16,3 +16,18 @@ brille24_customer_options_admin:
             index:
                 icon: cube
     type: sylius.resource
+
+brille24_admin_customer_option_archive:
+    path: /customer-option/{id}/archive
+    methods: [PATCH]
+    defaults:
+        _controller: brille24.controller.customer_option:updateAction
+        _sylius:
+            section: admin
+            permission: true
+            template: '@SyliusUi/Grid/Action/archive.html.twig'
+            form:
+                type: Sylius\Bundle\ResourceBundle\Form\Type\ArchivableType
+            redirect:
+                route: brille24_admin_customer_option_index
+                parameters: {}

--- a/src/Resources/config/app/routing/admin/customer_options.yml
+++ b/src/Resources/config/app/routing/admin/customer_options.yml
@@ -16,18 +16,3 @@ brille24_customer_options_admin:
             index:
                 icon: cube
     type: sylius.resource
-
-brille24_admin_customer_option_archive:
-    path: /customer-option/{id}/archive
-    methods: [PATCH]
-    defaults:
-        _controller: brille24.controller.customer_option:updateAction
-        _sylius:
-            section: admin
-            permission: true
-            template: '@SyliusUi/Grid/Action/archive.html.twig'
-            form:
-                type: Sylius\Bundle\ResourceBundle\Form\Type\ArchivableType
-            redirect:
-                route: brille24_admin_customer_option_index
-                parameters: {}

--- a/src/Resources/config/app/services.yml
+++ b/src/Resources/config/app/services.yml
@@ -1,14 +1,5 @@
 imports:
-  - { resource: "services/command.xml" }
-  - { resource: "services/controller.xml" }
-  - { resource: "services/eventListener.xml" }
-  - { resource: "services/repositories.xml" }
-  - { resource: "services/factory.xml" }
-  - { resource: "services/forms.xml" }
-  - { resource: "services/menuListener.xml" }
-  - { resource: "services/services.xml" }
-  - { resource: "services/fixtures.xml" }
-  - { resource: "services/validator.xml" }
+  - { resource: "services/*" }
 
 services:
   # Sonata

--- a/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
+++ b/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
@@ -17,6 +17,8 @@
         <field name="code" type="string" unique="true" nullable="false"/>
         <field name="required" type="boolean"/>
 
+        <field name="archivedAt" type="datetime" nullable="true" />
+
         <one-to-many
                 target-entity="Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionAssociationInterface"
                 mapped-by="option"

--- a/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
+++ b/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
@@ -47,5 +47,8 @@
                 <order-by-field name="id" direction="ASC"/>
             </order-by>
         </one-to-many>
+
+        <one-to-many field="orders" target-entity="Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOption"
+                     mapped-by="customerOption"/>
     </entity>
 </doctrine-mapping>

--- a/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
+++ b/src/Resources/config/doctrine/CustomerOptions.CustomerOption.orm.xml
@@ -17,8 +17,6 @@
         <field name="code" type="string" unique="true" nullable="false"/>
         <field name="required" type="boolean"/>
 
-        <field name="archivedAt" type="datetime" nullable="true" />
-
         <one-to-many
                 target-entity="Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionAssociationInterface"
                 mapped-by="option"

--- a/src/Resources/config/doctrine/OrderItemOption.orm.xml
+++ b/src/Resources/config/doctrine/OrderItemOption.orm.xml
@@ -12,7 +12,7 @@
         <field name="customerOptionType"/>
 
         <many-to-one target-entity="Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionInterface"
-                     field="customerOption" optional="true"
+                     field="customerOption" optional="true" inversed-by="orders"
         >
             <join-column on-delete="SET NULL" nullable="true"/>
         </many-to-one>

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -85,3 +85,4 @@ brille24:
     grid:
         options_remaining: "{0} |]0,Inf]und %count% weitere"
         options_empty: Leer
+        delete_not_allowed: 'Die Kundenoption kann nicht gelöscht werden, weil sie in Verwendung ist.'

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -86,3 +86,4 @@ brille24:
     grid:
         options_remaining: "{0} |]0,Inf]and %count% more"
         options_empty: Nothing to display
+        delete_not_allowed: 'You are not allowed to delete the customer option as it is used in an order'

--- a/src/Resources/views/CustomerOption/Buttons/delete.html.twig
+++ b/src/Resources/views/CustomerOption/Buttons/delete.html.twig
@@ -1,0 +1,11 @@
+{% import '@SyliusUi/Macro/buttons.html.twig' as buttons %}
+
+{% set path = options.link.url|default(path(options.link.route|default(grid.requestConfiguration.getRouteName('delete')), options.link.parameters|default({'id': data.id}))) %}
+
+{% if data.orders|length != null %}
+    <div title="{{ 'brille24.grid.delete_not_allowed'|trans }}">
+        {{ buttons.default(path, action.label, data.id, "delete", "disabled") }}
+    </div>
+{% else %}
+    {{ buttons.delete(path, action.label, true, data.id) }}
+{% endif %}


### PR DESCRIPTION
When a customer option is used in an order, then deleting it is disabled.

This also fixes the relation between OrderItemOption <-> CustomerOption