### PR TITLE
Replacing the direct channel with channel context

### DIFF
--- a/src/Factory/OrderItemOptionFactory.php
+++ b/src/Factory/OrderItemOptionFactory.php
@@ -20,6 +20,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Repository\CustomerOptionRepositoryInte
 use Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueResolverInterface;
 use Exception;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, FactoryInterface
@@ -72,7 +73,10 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
         $orderItemOption->setCustomerOptionValue($customerOptionValue);
 
         if ($customerOptionValue instanceof CustomerOptionValueInterface) {
-            $price = $customerOptionValue->getPriceForChannel($this->channelContext->getChannel());
+            /** @var ChannelInterface $channel */
+            $channel = $this->channelContext->getChannel();
+            $price   = $customerOptionValue->getPriceForChannel($channel);
+
             $orderItemOption->setPrice($price);
         }
 

--- a/src/Factory/OrderItemOptionFactory.php
+++ b/src/Factory/OrderItemOptionFactory.php
@@ -19,7 +19,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Enumerations\CustomerOptionTypeEnum;
 use Brille24\SyliusCustomerOptionsPlugin\Repository\CustomerOptionRepositoryInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueResolverInterface;
 use Exception;
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, FactoryInterface
@@ -30,9 +30,9 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
     private $factory;
 
     /**
-     * @var ChannelInterface
+     * @var ChannelContextInterface
      */
-    private $channel;
+    private $channelContext;
 
     /**
      * @var CustomerOptionRepositoryInterface
@@ -46,12 +46,12 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
 
     public function __construct(
         FactoryInterface $factory,
-        ChannelInterface $channel,
+        ChannelContextInterface $channelContext,
         CustomerOptionRepositoryInterface $customerOptionRepository,
         CustomerOptionValueResolverInterface $valueResolver
     ) {
         $this->factory                  = $factory;
-        $this->channel                  = $channel;
+        $this->channelContext           = $channelContext;
         $this->customerOptionRepository = $customerOptionRepository;
         $this->valueResolver            = $valueResolver;
     }
@@ -72,7 +72,7 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
         $orderItemOption->setCustomerOptionValue($customerOptionValue);
 
         if ($customerOptionValue instanceof CustomerOptionValueInterface) {
-            $price = $customerOptionValue->getPriceForChannel($this->channel);
+            $price = $customerOptionValue->getPriceForChannel($this->channelContext->getChannel());
             $orderItemOption->setPrice($price);
         }
 

--- a/src/Resources/config/app/services/factory.xml
+++ b/src/Resources/config/app/services/factory.xml
@@ -7,7 +7,7 @@
                 decorates="brille24.factory.order_item_option"
         >
             <argument type="service" id="brille24.customer_options_plugin.factory.order_item_option_factory.inner" />
-            <argument type="expression">service('sylius.context.channel').getChannel()</argument>
+            <argument type="service" id="sylius.context.channel" />
 
             <argument type="service" id="brille24.repository.customer_option"/>
             <argument type="service" id="brille24.customer_options_plugin.services.customer_option_value_resolver"/>

--- a/src/Resources/config/app/services/services.xml
+++ b/src/Resources/config/app/services/services.xml
@@ -22,7 +22,7 @@
 
         <service class="Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueRefresher"
                  id="brille24.sylius_customer_options_plugin.services.customer_option_value_refresher">
-            <argument type="expression">service('sylius.context.channel').getChannel()</argument>
+            <argument type="service" id="sylius.context.channel" />
 
             <tag name="sylius.order_processor" priority="60" />
         </service>

--- a/src/Services/CustomerOptionValueRefresher.php
+++ b/src/Services/CustomerOptionValueRefresher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Brille24\SyliusCustomerOptionsPlugin\Services;
 
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -12,12 +13,12 @@ use Webmozart\Assert\Assert;
 
 final class CustomerOptionValueRefresher implements OrderProcessorInterface
 {
-    /** @var ChannelInterface */
-    private $currentChannel;
+    /** @var ChannelContextInterface */
+    private $channelContext;
 
-    public function __construct(ChannelInterface $currentChannel)
+    public function __construct(ChannelContextInterface $channelContext)
     {
-        $this->currentChannel = $currentChannel;
+        $this->channelContext = $channelContext;
     }
 
     /**
@@ -51,7 +52,7 @@ final class CustomerOptionValueRefresher implements OrderProcessorInterface
             // values on the entity so that if the reference changes the values stay the same
             $orderItemOption->setCustomerOptionValue($customerOptionValue);
 
-            $price = $customerOptionValue->getPriceForChannel($this->currentChannel);
+            $price = $customerOptionValue->getPriceForChannel($this->channelContext->getChannel());
             Assert::notNull($price);
 
             // Same here: Copy the price onto the customer option to be independent of the customer option value object.

--- a/src/Services/CustomerOptionValueRefresher.php
+++ b/src/Services/CustomerOptionValueRefresher.php
@@ -6,7 +6,6 @@ namespace Brille24\SyliusCustomerOptionsPlugin\Services;
 
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
-use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Webmozart\Assert\Assert;

--- a/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
+++ b/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
@@ -16,6 +16,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Repository\CustomerOptionRepositoryInte
 use Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueResolverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
@@ -36,6 +37,8 @@ class OrderItemOptionFactoryTest extends TestCase
         $baseFactory->method('createNew')->willReturn(new OrderItemOption());
 
         $this->channel      = self::createMock(ChannelInterface::class);
+        $chanelProvider     = self::createConfiguredMock(ChannelContextInterface::class, ['getChannel' => $this->channel]);
+
         $customerOptionRepo = self::createMock(CustomerOptionRepositoryInterface::class);
         $customerOptionRepo->method('findOneByCode')->willReturnCallback(function (string $code) {
             if (array_key_exists($code, $this->customerOptions)) {
@@ -60,7 +63,7 @@ class OrderItemOptionFactoryTest extends TestCase
 
         $baseFactory->method('createNew')->willReturn(self::createMock(OrderItemOptionInterface::class));
 
-        $this->orderItemOptionFactory = new OrderItemOptionFactory($baseFactory, $this->channel, $customerOptionRepo, $valueResolver);
+        $this->orderItemOptionFactory = new OrderItemOptionFactory($baseFactory, $chanelProvider, $customerOptionRepo, $valueResolver);
     }
 
     private function addCustomerOption(CustomerOptionInterface $customerOption)

--- a/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
+++ b/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
@@ -13,6 +13,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueRefresher;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;
@@ -34,7 +35,10 @@ class CustomerOptionValueRefresherTest extends TestCase
     //<editor-fold desc="Helper function for setup">
     public function setUp(): void
     {
-        $channel                            = self::createMock(ChannelInterface::class);
+        $channel = self::createConfiguredMock(ChannelContextInterface::class, [
+            'getChannel' => self::createMock(ChannelInterface::class),
+        ]);
+
         $this->customerOptionValueRefresher = new CustomerOptionValueRefresher($channel);
     }
 


### PR DESCRIPTION
When using the channel context in the constructor it will query the
database. Which is a problem when the database is not yet set up.