### PR TITLE
Use order channel for order item option updates

### DIFF
--- a/src/Controller/EditCustomerOptionsAction.php
+++ b/src/Controller/EditCustomerOptionsAction.php
@@ -11,6 +11,7 @@ use Brille24\SyliusCustomerOptionsPlugin\Services\OrderItemOptionUpdaterInterfac
 use DateTime;
 use Exception;
 use Sylius\Bundle\ResourceBundle\Event\ResourceControllerEvent;
+use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Repository\OrderItemRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -57,12 +58,13 @@ class EditCustomerOptionsAction extends AbstractController
             new ResourceControllerEvent($orderItem)
         );
 
+        /** @var OrderInterface $order */
         $order = $orderItem->getOrder();
 
         $orderItemForm = $this->createForm(
             ShopCustomerOptionType::class,
             $this->getCustomerOptionValues($orderItem),
-            ['product' => $orderItem->getProduct(), 'mapped' => true]
+            ['product' => $orderItem->getProduct(), 'channel' => $order->getChannel(), 'mapped' => true]
         );
 
         $orderItemForm->handleRequest($request);

--- a/src/EventListener/AddToCartListener.php
+++ b/src/EventListener/AddToCartListener.php
@@ -88,11 +88,10 @@ final class AddToCartListener
             foreach ($valueArray as $value) {
                 // Creating the item
                 $salesOrderConfiguration = $this->orderItemOptionFactory->createNewFromStrings(
+                    $orderItem,
                     $customerOptionCode,
                     $value
                 );
-
-                $salesOrderConfiguration->setOrderItem($orderItem);
 
                 $this->entityManager->persist($salesOrderConfiguration);
 

--- a/src/Factory/OrderItemOptionFactoryInterface.php
+++ b/src/Factory/OrderItemOptionFactoryInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Brille24\SyliusCustomerOptionsPlugin\Factory;
 
 use Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionInterface;
+use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 
 interface OrderItemOptionFactoryInterface
@@ -23,7 +24,11 @@ interface OrderItemOptionFactoryInterface
      *
      * @return OrderItemOptionInterface
      */
-    public function createForOptionAndValue(CustomerOptionInterface $customerOption, $customerOptionValue): OrderItemOptionInterface;
+    public function createForOptionAndValue(
+        OrderItemInterface $orderItem,
+        CustomerOptionInterface $customerOption,
+        $customerOptionValue
+    ): OrderItemOptionInterface;
 
     /**
      * Creates an OrderItemOption based on the two input strings
@@ -34,6 +39,7 @@ interface OrderItemOptionFactoryInterface
      * @return OrderItemOptionInterface
      */
     public function createNewFromStrings(
+        OrderItemInterface $orderItem,
         string $customerOptionCode,
         string $customerOptionValue
     ): OrderItemOptionInterface;

--- a/src/Factory/OrderItemOptionFactoryInterface.php
+++ b/src/Factory/OrderItemOptionFactoryInterface.php
@@ -21,6 +21,7 @@ interface OrderItemOptionFactoryInterface
     /**
      * @param CustomerOptionInterface $customerOption
      * @param mixed                   $customerOptionValue
+     * @param OrderItemInterface $orderItem
      *
      * @return OrderItemOptionInterface
      */
@@ -35,6 +36,7 @@ interface OrderItemOptionFactoryInterface
      *
      * @param string $customerOptionCode The code of teh customer option
      * @param string $customerOptionValue The code of the value if it is a select else just the value itself
+     * @param OrderItemInterface $orderItem
      *
      * @return OrderItemOptionInterface
      */

--- a/src/Form/Product/ShopCustomerOptionType.php
+++ b/src/Form/Product/ShopCustomerOptionType.php
@@ -117,6 +117,7 @@ final class ShopCustomerOptionType extends AbstractType
      * @param array                   $formOptions
      * @param CustomerOptionInterface $customerOption
      * @param ProductInterface        $product
+     * @param ChannelInterface $channel
      *
      * @return array
      */
@@ -180,6 +181,7 @@ final class ShopCustomerOptionType extends AbstractType
     /**
      * @param CustomerOptionValueInterface $value
      * @param ProductInterface             $product
+     * @param ChannelInterface $channel
      *
      * @return string
      *

--- a/src/Resources/config/app/services/factory.xml
+++ b/src/Resources/config/app/services/factory.xml
@@ -7,7 +7,6 @@
                 decorates="brille24.factory.order_item_option"
         >
             <argument type="service" id="brille24.customer_options_plugin.factory.order_item_option_factory.inner" />
-            <argument type="service" id="sylius.context.channel" />
 
             <argument type="service" id="brille24.repository.customer_option"/>
             <argument type="service" id="brille24.customer_options_plugin.services.customer_option_value_resolver"/>

--- a/src/Resources/config/app/services/services.xml
+++ b/src/Resources/config/app/services/services.xml
@@ -22,8 +22,6 @@
 
         <service class="Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueRefresher"
                  id="brille24.sylius_customer_options_plugin.services.customer_option_value_refresher">
-            <argument type="service" id="sylius.context.channel" />
-
             <tag name="sylius.order_processor" priority="60" />
         </service>
 

--- a/src/Services/OrderItemOptionUpdater.php
+++ b/src/Services/OrderItemOptionUpdater.php
@@ -82,8 +82,7 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
 
             // Make sure we have an OrderItemOption
             if (null === $orderItemOption) {
-                $orderItemOption = $this->orderItemOptionFactory->createForOptionAndValue($customerOption, '');
-                $orderItemOption->setOrderItem($orderItem);
+                $orderItemOption = $this->orderItemOptionFactory->createForOptionAndValue($orderItem, $customerOption, '');
             }
 
             // Select & Date options need to be handled differently
@@ -96,8 +95,7 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
                 case CustomerOptionTypeEnum::MULTI_SELECT:
                     // Create an option value for every selected value
                     foreach ($newValue as $value) {
-                        $orderItemOption = $this->orderItemOptionFactory->createForOptionAndValue($customerOption, '');
-                        $orderItemOption->setOrderItem($orderItem);
+                        $orderItemOption = $this->orderItemOptionFactory->createForOptionAndValue($orderItem, $customerOption, '');
                         $orderItemOption->setCustomerOptionValue($value);
                         $newConfig[] = $orderItemOption;
                     }

--- a/tests/PHPUnit/EventListener/AddToCartListenerTest.php
+++ b/tests/PHPUnit/EventListener/AddToCartListenerTest.php
@@ -68,12 +68,15 @@ class AddToCartListenerTest extends TestCase
 
         $orderItemOptionFactory = self::createMock(OrderItemOptionFactoryInterface::class);
         $orderItemOptionFactory->method('createNewFromStrings')->willReturnCallback(
-            function ($customerOptionCode, $value) {
+            function ($orderItem, $customerOptionCode, $value) {
                 if (!array_key_exists($customerOptionCode, $this->customerOptions)) {
                     throw new \Exception('Not found');
                 }
 
-                return new OrderItemOption($this->channel, $this->customerOptions[$customerOptionCode], $value);
+                $orderItemOption = new OrderItemOption($this->channel, $this->customerOptions[$customerOptionCode], $value);
+                $orderItemOption->setOrderItem($orderItem);
+
+                return $orderItemOption;
             }
         );
 
@@ -94,7 +97,8 @@ class AddToCartListenerTest extends TestCase
     {
         $product = self::createConfiguredMock(ProductInterface::class, []);
 
-        $order     = self::createMock(OrderInterface::class);
+        $channel   = self::createMock(ChannelInterface::class);
+        $order     = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $channel]);
         $orderItem = self::createMock(OrderItemInterface::class);
         $orderItem->method('getOrder')->willReturn($hasOrder ? $order : null);
         $orderItem->method('getProduct')->willReturn($product);

--- a/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
+++ b/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
@@ -82,8 +82,8 @@ class OrderItemOptionFactoryTest extends TestCase
 
     public function testCreateForOptionAndValue(): void
     {
-        $order = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
-        $orderItem = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order]);
+        $order          = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
+        $orderItem      = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order]);
         $customerOption = self::createMock(CustomerOptionInterface::class);
         $value          = 'something';
 
@@ -102,7 +102,7 @@ class OrderItemOptionFactoryTest extends TestCase
 
     public function testCreateNewFromStringWithInvalidValue()
     {
-        $orderItem = self::createMock(OrderItemInterface::class);
+        $orderItem      = self::createMock(OrderItemInterface::class);
         $customerOption = $this->createCustomerOption('something');
         $customerOption->method('getValues')->willReturn(new ArrayCollection());
 
@@ -126,7 +126,7 @@ class OrderItemOptionFactoryTest extends TestCase
         $customerOption = $this->createCustomerOption('something');
         $customerOption->method('getValues')->willReturn(new ArrayCollection([$customerOptionValue]));
 
-        $order = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
+        $order     = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
         $orderItem = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order]);
 
         $this->addCustomerOption($customerOption);

--- a/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
+++ b/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
@@ -32,20 +32,22 @@ class CustomerOptionValueRefresherTest extends TestCase
     /** @var int */
     private $priceUpdate;
 
+    /** @var ChannelInterface */
+    private $channel;
+
     //<editor-fold desc="Helper function for setup">
     public function setUp(): void
     {
-        $channel = self::createConfiguredMock(ChannelContextInterface::class, [
-            'getChannel' => self::createMock(ChannelInterface::class),
-        ]);
+        $this->channel = self::createMock(ChannelInterface::class);
 
-        $this->customerOptionValueRefresher = new CustomerOptionValueRefresher($channel);
+        $this->customerOptionValueRefresher = new CustomerOptionValueRefresher();
     }
 
     private function createOrder(array $orderItems): OrderInterface
     {
         $order = self::createMock(OrderInterface::class);
         $order->method('getItems')->willReturn(new ArrayCollection($orderItems));
+        $order->method('getChannel')->willReturn($this->channel);
 
         return $order;
     }
@@ -146,7 +148,8 @@ class CustomerOptionValueRefresherTest extends TestCase
         );
 
         $this->customerOptionValueRefresher->copyOverValuesForOrderItem(
-            $this->createOrderItem($orderItemOption)
+            $this->createOrderItem($orderItemOption),
+            $this->channel
         );
 
         self::assertEquals(2, $this->updateCount);

--- a/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
+++ b/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
@@ -13,7 +13,6 @@ use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemOptionInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Services\CustomerOptionValueRefresher;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;


### PR DESCRIPTION
We used the `ChannelContext` for `OrderItemOption` updaes in the admin area.
Because of this, the order channel was ignored and possibly for the wrong channel used for price calculations.