### PR TITLE
Fixing the customer option price resolution

### DIFF
--- a/src/Entity/CustomerOptions/CustomerOptionValueInterface.php
+++ b/src/Entity/CustomerOptions/CustomerOptionValueInterface.php
@@ -14,6 +14,7 @@ namespace Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions;
 
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 use Sylius\Component\Resource\Model\TranslatableInterface;
 
@@ -51,12 +52,14 @@ interface CustomerOptionValueInterface extends ResourceInterface, TranslatableIn
 
     /**
      * @param ChannelInterface $channel
+     * @param ProductInterface $product
      * @param bool             $ignoreActive
      *
      * @return CustomerOptionValuePriceInterface
      */
     public function getPriceForChannel(
         ChannelInterface $channel,
+        ProductInterface $product,
         bool $ignoreActive = false
     ): ?CustomerOptionValuePriceInterface;
 

--- a/src/Factory/OrderItemOptionFactory.php
+++ b/src/Factory/OrderItemOptionFactory.php
@@ -75,7 +75,7 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
 
             /** @var ChannelInterface $channel */
             $channel = $order->getChannel();
-            $price   = $customerOptionValue->getPriceForChannel($channel);
+            $price   = $customerOptionValue->getPriceForChannel($channel, $orderItem->getProduct());
 
             $orderItemOption->setPrice($price);
         }

--- a/src/Form/Product/ShopCustomerOptionType.php
+++ b/src/Form/Product/ShopCustomerOptionType.php
@@ -207,7 +207,7 @@ final class ShopCustomerOptionType extends AbstractType
             }
         }
 
-        $price = $price ?? $value->getPriceForChannel($channel);
+        $price = $price ?? $value->getPriceForChannel($channel, $product);
 
         // No price was found for the current channel, probably because the values weren't updated after adding a new channel
         if ($price === null) {

--- a/src/Resources/config/doctrine/CustomerOptions.CustomerOptionValuePrice.orm.xml
+++ b/src/Resources/config/doctrine/CustomerOptions.CustomerOptionValuePrice.orm.xml
@@ -28,9 +28,7 @@
         </many-to-one>
 
         <many-to-one target-entity="Sylius\Component\Product\Model\ProductInterface"
-                     field="product" inversed-by="customerOptionValuePrices"
-        >
-        </many-to-one>
+                     field="product" inversed-by="customerOptionValuePrices" />
 
         <one-to-one field="dateValid" target-entity="Brille24\SyliusCustomerOptionsPlugin\Entity\Tools\DateRange">
             <cascade>

--- a/src/Services/CustomerOptionValueRefresher.php
+++ b/src/Services/CustomerOptionValueRefresher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusCustomerOptionsPlugin\Services;
 
+use Brille24\SyliusCustomerOptionsPlugin\Entity\CustomerOptions\CustomerOptionValueInterface;
 use Brille24\SyliusCustomerOptionsPlugin\Entity\OrderItemInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Order\Model\OrderInterface;
@@ -33,7 +34,9 @@ final class CustomerOptionValueRefresher implements OrderProcessorInterface
     public function copyOverValuesForOrderItem(OrderItemInterface $orderItem, ChannelInterface $channel): void
     {
         $orderItemOptions = $orderItem->getCustomerOptionConfiguration();
+        $product          = $orderItem->getProduct();
         foreach ($orderItemOptions as $orderItemOption) {
+            /** @var CustomerOptionValueInterface $customerOptionValue */
             // Gets the object reference to the customer option value
             $customerOptionValue = $orderItemOption->getCustomerOptionValue();
             if ($customerOptionValue === null) {
@@ -44,8 +47,8 @@ final class CustomerOptionValueRefresher implements OrderProcessorInterface
             // values on the entity so that if the reference changes the values stay the same
             $orderItemOption->setCustomerOptionValue($customerOptionValue);
 
-            $price = $customerOptionValue->getPriceForChannel($channel);
-            Assert::notNull($price);
+            $price = $customerOptionValue->getPriceForChannel($channel, $product);
+            Assert::notNull($price, 'The customer option value "'.$customerOptionValue->getCode().'" has no price');
 
             // Same here: Copy the price onto the customer option to be independent of the customer option value object.
             $orderItemOption->setPrice($price);

--- a/tests/Behat/Context/SetupContext.php
+++ b/tests/Behat/Context/SetupContext.php
@@ -248,7 +248,9 @@ class SetupContext implements Context
                     Assert::notNull($customerOptionValue);
 
                     $itemOption->setCustomerOptionValue($customerOptionValue);
-                    $itemOption->setPrice($customerOptionValue->getPriceForChannel($this->channelContext->getChannel()));
+                    $itemOption->setPrice(
+                        $customerOptionValue->getPriceForChannel($this->channelContext->getChannel(), $orderItem->getProduct())
+                    );
                 } else {
                     $itemOption->setOptionValue($value);
                 }

--- a/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
+++ b/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
@@ -19,6 +19,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 class OrderItemOptionFactoryTest extends TestCase
@@ -82,8 +83,9 @@ class OrderItemOptionFactoryTest extends TestCase
 
     public function testCreateForOptionAndValue(): void
     {
+        $product        = self::createMock(ProductInterface::class);
         $order          = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
-        $orderItem      = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order]);
+        $orderItem      = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order, 'getProduct' => $product]);
         $customerOption = self::createMock(CustomerOptionInterface::class);
         $value          = 'something';
 
@@ -126,8 +128,9 @@ class OrderItemOptionFactoryTest extends TestCase
         $customerOption = $this->createCustomerOption('something');
         $customerOption->method('getValues')->willReturn(new ArrayCollection([$customerOptionValue]));
 
+        $product   = self::createMock(ProductInterface::class);
         $order     = self::createConfiguredMock(OrderInterface::class, ['getChannel' => $this->channel]);
-        $orderItem = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order]);
+        $orderItem = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => $order, 'getProduct' => $product]);
 
         $this->addCustomerOption($customerOption);
 

--- a/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
+++ b/tests/PHPUnit/Service/CustomerOptionValueRefresherTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;
+use Sylius\Component\Core\Model\ProductInterface;
 
 class CustomerOptionValueRefresherTest extends TestCase
 {
@@ -109,11 +110,13 @@ class CustomerOptionValueRefresherTest extends TestCase
     private function createOrderItem($orderItemOption): Brille24OrderItem
     {
         $orderItem = self::createMock(Brille24OrderItem::class);
+        $product   = self::createMock(ProductInterface::class);
 
         if (!is_array($orderItemOption)) {
             $orderItemOption = [$orderItemOption];
         }
         $orderItem->method('getCustomerOptionConfiguration')->willReturn($orderItemOption);
+        $orderItem->method('getProduct')->willReturn($product);
 
         return $orderItem;
     }


### PR DESCRIPTION
The problem is: If multiple product-overrides exist then it always took the last product override no matter what product it belonged to.