### PR TITLE
Add config to control if the order item price should be recalculated…

### DIFF
--- a/src/Controller/EditCustomerOptionsAction.php
+++ b/src/Controller/EditCustomerOptionsAction.php
@@ -30,14 +30,19 @@ class EditCustomerOptionsAction extends AbstractController
     /** @var EventDispatcherInterface */
     private $eventDispatcher;
 
+    /** @var bool */
+    private $recalculatePrice;
+
     public function __construct(
         OrderItemRepositoryInterface $orderItemRepository,
         OrderItemOptionUpdaterInterface $orderItemOptionUpdater,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        bool $recalculatePrice
     ) {
         $this->orderItemRepository    = $orderItemRepository;
         $this->orderItemOptionUpdater = $orderItemOptionUpdater;
         $this->eventDispatcher        = $eventDispatcher;
+        $this->recalculatePrice = $recalculatePrice;
     }
 
     /**
@@ -70,7 +75,7 @@ class EditCustomerOptionsAction extends AbstractController
         $orderItemForm->handleRequest($request);
 
         if ($orderItemForm->isSubmitted() && $orderItemForm->isValid()) {
-            $this->orderItemOptionUpdater->updateOrderItemOptions($orderItem, $orderItemForm->getData());
+            $this->orderItemOptionUpdater->updateOrderItemOptions($orderItem, $orderItemForm->getData(), $this->recalculatePrice);
 
             $this->eventDispatcher->dispatch(
                 'brille24.order_item.post_update',

--- a/src/DependencyInjection/Brille24SyliusCustomerOptionsExtension.php
+++ b/src/DependencyInjection/Brille24SyliusCustomerOptionsExtension.php
@@ -28,6 +28,7 @@ final class Brille24SyliusCustomerOptionsExtension extends Extension implements 
         $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
 
         $container->setParameter('brille24.sylius_customer_options.price_import_example_file_path', $config['price_import_example_file_path']);
+        $container->setParameter('brille24.sylius_customer_options.order_item_edit.recalculate_price', $config['order_item_edit']['recalculate_price']);
 
         new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/app'));
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -36,6 +36,7 @@ final class Configuration implements ConfigurationInterface
         // Adding new resources
         $this->addResourceSection($rootNode);
         $this->addPriceImportSection($rootNode);
+        $this->addOrderItemEditSection($rootNode);
 
         return $treeBuilder;
     }
@@ -118,6 +119,20 @@ final class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('price_import_example_file_path')
                     ->defaultValue(__DIR__.'/../Resources/example/price_import.csv')
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addOrderItemEditSection(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('order_item_edit')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('recalculate_price')->defaultTrue()->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Resources/config/app/services/controller.xml
+++ b/src/Resources/config/app/services/controller.xml
@@ -7,6 +7,7 @@
             <argument type="service" id="sylius.repository.order_item" />
             <argument type="service" id="brille24.sylius_customer_options_plugin.services.order_item_option_updater" />
             <argument type="service" id="event_dispatcher" />
+            <argument>%brille24.sylius_customer_options.order_item_edit.recalculate_price%</argument>
 
             <tag name="controller.service_arguments" />
         </service>

--- a/src/Services/OrderItemOptionUpdater.php
+++ b/src/Services/OrderItemOptionUpdater.php
@@ -48,7 +48,7 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
     }
 
     /** {@inheritdoc} */
-    public function updateOrderItemOptions(OrderItemInterface $orderItem, array $data): void
+    public function updateOrderItemOptions(OrderItemInterface $orderItem, array $data, bool $updatePrice = true): void
     {
         $orderItemOptions = $orderItem->getCustomerOptionConfiguration(true);
 
@@ -121,7 +121,10 @@ final class OrderItemOptionUpdater implements OrderItemOptionUpdaterInterface
         $orderItem->setCustomerOptionConfiguration($newConfig);
 
         $this->customerOptionRefresher->process($orderItem->getOrder());
-        $this->customerOptionRecalculator->process($orderItem->getOrder());
+
+        if ($updatePrice) {
+            $this->customerOptionRecalculator->process($orderItem->getOrder());
+        }
 
         $this->entityManager->flush();
     }

--- a/src/Services/OrderItemOptionUpdaterInterface.php
+++ b/src/Services/OrderItemOptionUpdaterInterface.php
@@ -15,6 +15,7 @@ interface OrderItemOptionUpdaterInterface
      * @param array<string, mixed> $data
      *     Associative array of key value pairs for the new array.
      *     The key is the custom option code and the value is the new value.
+     * @param bool $updatePrice
      */
-    public function updateOrderItemOptions(OrderItemInterface $orderItem, array $data): void;
+    public function updateOrderItemOptions(OrderItemInterface $orderItem, array $data, bool $updatePrice = true): void;
 }


### PR DESCRIPTION
Adds config to control if the order item price should be recalculated after you change the customer option values in the admin section.

This way you don't have to override the `OrderItemOptionUpdater` to disable recalculation.