### PR TITLE
Fixing add to cart when no custom option is passed through the form

### DIFF
--- a/src/Form/Product/ShopCustomerOptionType.php
+++ b/src/Form/Product/ShopCustomerOptionType.php
@@ -93,17 +93,22 @@ final class ShopCustomerOptionType extends AbstractType
             }
         );
 
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($customerOptionTypesByCode): void {
-            $data = $event->getData();
-
-            foreach ($data as $customerOptionCode => $customerOptionValue) {
-                if (CustomerOptionTypeEnum::FILE === $customerOptionTypesByCode[$customerOptionCode]) {
-                    $data[$customerOptionCode] = $customerOptionValue['data'];
+        $builder->addEventListener(
+            FormEvents::PRE_SUBMIT,
+            static function (FormEvent $event) use ($customerOptionTypesByCode): void {
+                $data = $event->getData();
+                if (!is_array($data)) {
+                    return;
                 }
-            }
+                foreach ($data as $customerOptionCode => $customerOptionValue) {
+                    if (CustomerOptionTypeEnum::FILE === $customerOptionTypesByCode[$customerOptionCode]) {
+                        $data[$customerOptionCode] = $customerOptionValue['data'];
+                    }
+                }
 
-            $event->setData($data);
-        });
+                $event->setData($data);
+            }
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver): void


### PR DESCRIPTION
When no custom option data is sent through the add to cart form, it raised an error as the foreach variable is null.

`Warning: foreach() argument must be of type array|object, null given`

Just adding the same check as the listener above.