### PR TITLE
Symfony 6 compatibility: Fix compiler pass resolving argument error

### DIFF
--- a/src/CompilerPass/AddingTypesToAdjustmentClearerPass.php
+++ b/src/CompilerPass/AddingTypesToAdjustmentClearerPass.php
@@ -17,6 +17,9 @@ final class AddingTypesToAdjustmentClearerPass implements CompilerPassInterface
 
         // Getting the new list of adjustment types to clear
         $listOfAdjustmentsToClear = $clearerDefinition->getArgument(0);
+        if (1 === preg_match('/^%(.*)%$/', $listOfAdjustmentsToClear, $matches)) {
+            $listOfAdjustmentsToClear = $container->getParameter($matches[1]);
+        }
         $listOfAdjustmentsToClear[] = CustomerOptionRecalculator::CUSTOMER_OPTION_ADJUSTMENT;
 
         // Setting the new list as the new definition


### PR DESCRIPTION
Symfony 6 slightly changed how it handles parameters during container compilation. Parameters are kept as placeholders (e.g., %sylius.order_processing.adjustment_clearing_types%) until much later in the compilation process.
Because of this, when the value of the first argument of the sylius.order_processing.order_adjustments_clearer service is retrieved, we get "%sylius.order_processing.adjustment_clearing_types%" instead of its resolved value which is the array defined in the order_processing.xml file.

We then have the error "[] operator not supported for strings".

Without the fix, it is not possible to upgrade to Sylius 1.12.