### PR TITLE
Fix unset order issue in OrderItemOptionFactory

### DIFF
--- a/src/Factory/OrderItemOptionFactory.php
+++ b/src/Factory/OrderItemOptionFactory.php
@@ -25,6 +25,7 @@ use Exception;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 
 class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, FactoryInterface
@@ -34,6 +35,7 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
         private CustomerOptionRepositoryInterface $customerOptionRepository,
         private CustomerOptionValueResolverInterface $valueResolver,
         private CustomerOptionValuePriceRepositoryInterface $customerOptionValuePriceRepository,
+        private CartContextInterface $cartContext,
     )
     {
     }
@@ -58,7 +60,7 @@ class OrderItemOptionFactory implements OrderItemOptionFactoryInterface, Factory
 
         if ($customerOptionValue instanceof CustomerOptionValueInterface) {
             /** @var OrderInterface $order */
-            $order = $orderItem->getOrder();
+            $order = $orderItem->getOrder() ?? $this->cartContext->getCart();
 
             /** @var ProductInterface $product */
             $product = $orderItem->getProduct();

--- a/src/Resources/config/app/services/factory.xml
+++ b/src/Resources/config/app/services/factory.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="brille24.repository.customer_option"/>
             <argument type="service" id="brille24.customer_options_plugin.services.customer_option_value_resolver"/>
             <argument type="service" id="brille24.repository.customer_option_value_price"/>
+            <argument type="service" id="sylius.context.cart"/>
         </service>
 
         <service

--- a/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
+++ b/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
@@ -30,6 +30,10 @@ class OrderItemOptionFactoryTest extends TestCase
 
     private \Sylius\Component\Core\Model\ChannelInterface $channel;
 
+    private \Sylius\Component\Core\Model\OrderInterface $cart;
+
+    private \Sylius\Component\Order\Context\CartContextInterface $cartContext;
+
     public function setUp(): void
     {
         $baseFactory = self::createMock(FactoryInterface::class);
@@ -65,7 +69,17 @@ class OrderItemOptionFactoryTest extends TestCase
         $customerOptionValuePriceRepository = self::createMock(CustomerOptionValuePriceRepositoryInterface::class);
         $customerOptionValuePriceRepository->method('getPriceForChannel')->willReturn($customerOptionValuePrice);
 
-        $this->orderItemOptionFactory = new OrderItemOptionFactory($baseFactory, $customerOptionRepo, $valueResolver, $customerOptionValuePriceRepository);
+        $this->cart = self::createMock(OrderInterface::class);
+        $this->cartContext = self::createMock(\Sylius\Component\Order\Context\CartContextInterface::class);
+        $this->cartContext->method('getCart')->willReturnCallback(fn() => $this->cart);
+
+        $this->orderItemOptionFactory = new OrderItemOptionFactory(
+            $baseFactory,
+            $customerOptionRepo,
+            $valueResolver,
+            $customerOptionValuePriceRepository,
+            $this->cartContext
+        );
     }
 
     private function addCustomerOption(CustomerOptionInterface $customerOption)

--- a/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
+++ b/tests/PHPUnit/Factory/OrderItemOptionFactoryTest.php
@@ -154,4 +154,28 @@ class OrderItemOptionFactoryTest extends TestCase
         self::assertEquals($customerOptionValue, $orderItemOption->getCustomerOptionValue());
         self::assertEquals($customerOptionValue->getCode(), $orderItemOption->getCustomerOptionValueCode());
     }
+
+    public function testCreateNewFromStringWithValidValueWithoutOrder()
+    {
+        $customerOptionValuePrice = self::createMock(CustomerOptionValuePriceInterface::class);
+
+        $customerOptionValue = self::createMock(CustomerOptionValueInterface::class);
+        $customerOptionValue->method('getCode')->willReturn('value');
+        $customerOptionValue->method('getName')->willReturn('some value');
+        $customerOptionValue->method('getPriceForChannel')->with($this->channel)->willReturn($customerOptionValuePrice);
+
+        $customerOption = $this->createCustomerOption('something');
+        $customerOption->method('getValues')->willReturn(new ArrayCollection([$customerOptionValue]));
+
+        $product = self::createMock(ProductInterface::class);
+        $this->cart->method('getChannel')->willReturn($this->channel);
+        $orderItem = self::createConfiguredMock(OrderItemInterface::class, ['getOrder' => null, 'getProduct' => $product]);
+
+        $this->addCustomerOption($customerOption);
+
+        $orderItemOption = $this->orderItemOptionFactory->createNewFromStrings($orderItem, 'something', 'value');
+
+        self::assertEquals($customerOptionValue, $orderItemOption->getCustomerOptionValue());
+        self::assertEquals($customerOptionValue->getCode(), $orderItemOption->getCustomerOptionValueCode());
+    }
 }


### PR DESCRIPTION
This PR tries to resolve the issue that is encountered when adding a  product to a cart, which has a mandatory option of type "Select". This previously caused an `Call to a member function on null` error.

This resolves #146 

Tested in:
- Sylius 1.14 and PHP 8.1
- Sylius 1.12 and PHP 8.0

I had some issues getting the plugins test suit to run and when it did there where also existing test failing.
I adjusted the OrderItemOptionFactory's PHPUnit test suite and added a new case that would have failed before this PR's patch.